### PR TITLE
Support stream names in 'bname.zip:fname.truck' format.

### DIFF
--- a/RoR_client.py
+++ b/RoR_client.py
@@ -66,14 +66,14 @@ playerColours = [
 
 # Name may be in "bname:fname.truck" format, where 'bundle' is ZIP/subdir in modcache. See https://github.com/RigsOfRods/rigs-of-rods/pull/3171
 def getTruckFilenameFromStreamName(streamName):
-    if ':' in streamName:
+    if b':' in streamName:
         return streamName.split(b':')[1]
     else:
         return streamName
         
 # Name may be in "bname:fname.truck" format, where 'bundle' is ZIP/subdir in modcache. See https://github.com/RigsOfRods/rigs-of-rods/pull/3171
 def getTruckBundleNameFromStreamName(streamName):
-    if ':' in streamName:
+    if b':' in streamName:
         return streamName.split(b':')[0]
     else:
         return streamName

--- a/RoR_client.py
+++ b/RoR_client.py
@@ -70,6 +70,13 @@ def getTruckFilenameFromStreamName(streamName):
         return streamName.split(b':')[1]
     else:
         return streamName
+        
+# Name may be in "bname:fname.truck" format, where 'bundle' is ZIP/subdir in modcache. See https://github.com/RigsOfRods/rigs-of-rods/pull/3171
+def getTruckBundleNameFromStreamName(streamName):
+    if ':' in streamName:
+        return streamName.split(b':')[0]
+    else:
+        return streamName
 
 def getTruckName(filename):
     if filename in TruckToName.list:
@@ -81,10 +88,12 @@ def getTruckType(filename):
 
 def getTruckInfo(streamName):
     filename = getTruckFilenameFromStreamName(streamName)
+    bundlename = getTruckBundleNameFromStreamName(streamName)
     return {
             'type': getTruckType(filename),
             'name': getTruckName(filename),
             'file': filename,
+            'bundle':bundlename
     }
 
 class interruptReceived(Exception):

--- a/RoR_client.py
+++ b/RoR_client.py
@@ -64,6 +64,13 @@ playerColours = [
         "#999900"
 ];
 
+# Name may be in "bname:fname.truck" format, where 'bundle' is ZIP/subdir in modcache. See https://github.com/RigsOfRods/rigs-of-rods/pull/3171
+def getTruckFilenameFromStreamName(streamName):
+    if ':' in streamName:
+        return streamName.split(b':')[1]
+    else:
+        return streamName
+
 def getTruckName(filename):
     if filename in TruckToName.list:
         return TruckToName.list[filename]
@@ -72,7 +79,8 @@ def getTruckName(filename):
 def getTruckType(filename):
     return filename.split(b'.').pop().lower()
 
-def getTruckInfo(filename):
+def getTruckInfo(streamName):
+    filename = getTruckFilenameFromStreamName(streamName)
     return {
             'type': getTruckType(filename),
             'name': getTruckName(filename),
@@ -468,8 +476,8 @@ class Discord_Layer:
     # [game] <username> is now driving a <truckname> (streams: <number of streams>/<limit of streams>)
     def sayStreamReg(self, uid, stream):
         truckinfo =  getTruckInfo(stream.name);
-        invalid = self.main.validate(s(truckinfo['file']))
-        if invalid:
+        banned = self.main.isVehicleBanned(s(truckinfo['file']))
+        if banned:
             self.sayInfo("User **%s** with uid **%s** has spawned a **%s** which is a banned vehicle." % (self.sm.getUsername(uid), uid, s(truckinfo['file'])))
             self.main.queueKick(self.channelID, int(uid))
         else:

--- a/RoRnet.py
+++ b/RoRnet.py
@@ -1,6 +1,6 @@
 import struct, logging, time
 
-RORNET_VERSION = "RoRnet_2.44"
+RORNET_VERSION = "RoRnet_2.45"
 
 MSG2_HELLO                      = 1025                #!< client sends its version as first message
 # hello responses

--- a/services_start.py
+++ b/services_start.py
@@ -317,7 +317,7 @@ class Main(discord.Client):
                 self.RoRclients[ID].setName('RoR_thread_'+ID)
                 self.RoRclients[ID].start()
 
-    def validate(self, truck):
+    def isVehicleBanned(self, truck):
         if os.path.isfile('truck.blacklist') == False:
             return False
 


### PR DESCRIPTION
This is a bundle-qualified format, where 'bundle' is ZIP/subdir in modcache. See https://github.com/RigsOfRods/rigs-of-rods/pull/3171

Code changes:
- RoR_client: new function `getTruckFilenameFromStreamName()` with commentary. Existing `getTruckInfo()` extended to use it. 
- services_start: just renamed the banlist-scanning function for clarity

Tested to work by CuriousMike56 : https://discord.com/channels/136544456244461568/189904947649708032/1311582678050672683