### PR TITLE
"Ban evader" system

### DIFF
--- a/RoR_client.py
+++ b/RoR_client.py
@@ -439,7 +439,13 @@ class Discord_Layer:
 
     # [game] <username> (<language>) joined the server, using <version>
     def sayJoin(self, uid):
-        self.__send("%s (%s) joined the server, using %s %s." % (self.sm.getUsername(uid),  s(self.sm.getLanguage(uid)), s(self.sm.getClientName(uid)), s(self.sm.getClientVersion(uid))), "game")
+        userinfo = self.sm.getUsername(uid);
+        invalid = self.main.checkthrough(userinfo)
+        if invalid:
+            self.sayInfo("User **%s** with uid **%s** was identified as a habitual ban evader and was banned again." % (self.sm.getUsername(uid), uid))
+            self.main.queueBan(self.channelID, int(uid))
+        else:
+            self.__send("%s (%s) joined the server, using %s %s." % (self.sm.getUsername(uid),  s(self.sm.getLanguage(uid)), s(self.sm.getClientName(uid)), s(self.sm.getClientVersion(uid))), "game")
 
     # [game] <username> left the server
     def sayLeave(self, uid):


### PR DESCRIPTION
Using much of the existing logic for handling truck bans across all servers a RoRBot is deployed to, I've repurposed it to check usernames against a list when they first join. If a username is found on the list, the user is banned. This should help automate much of the process usually undertaken when dealing with a "ban evader", since such a situation is determined by name recognition anyway.