### PR TITLE
Add per-server RoRNet protocol configuration and socket cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![RoRBot](https://i.imgur.com/wUJdzYp.png)
 
-This is a bot for Rigs of Rods multiplayer servers running RoRNet 2.43 (RoR version 2021.04+)
+This is a bot for Rigs of Rods multiplayer servers running RoRNet 2.44 (RoR version 2022.12+)
 
 # Features
 
@@ -13,8 +13,7 @@ This is a bot for Rigs of Rods multiplayer servers running RoRNet 2.43 (RoR vers
 
 # Installation (Outdated)
 
-An in-depth installation guide can be found on the [Wiki](https://github.com/CuriousMike56/RoRServerBot/wiki), along with a [configuration guide](https://github.com/CuriousMike56/RoRServerBot/wiki/Configuration) and a [commands list](https://github.com/CuriousMike56/RoRServerBot/wiki/Commands).
-
+An in-depth installation guide can be found on the [Wiki](https://github.com/tritonas00/RoRServerBot/wiki), along with a [configuration guide](https://github.com/tritonas00/RoRServerBot/wiki/Configuration) and a [commands list](https://github.com/tritonas00/RoRServerBot/wiki/Commands).
 # Credits
 
 - Neorej16 and contributors - Original bot code 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 
 ![RoRBot](https://i.imgur.com/wUJdzYp.png)
 
-This is a bot for Rigs of Rods multiplayer servers running RoRNet 2.44 (RoR version 2022.12+)
+This is a bot for Rigs of Rods multiplayer servers running RoRNet 2.43 (RoR version 2021.04+)
 
 # Features
 
 - Monitor and control RoR servers outside of RoR via Discord
+- Global and per-server bot admins 
 - Vehicle recording and playback (Video demo: https://streamable.com/lecig)
 - Extra commands 
 
-# Installation
+# Installation (Outdated)
 
-An in-depth installation guide can be found on the [Wiki](https://github.com/tritonas00/RoRServerBot/wiki), along with a [configuration guide](https://github.com/tritonas00/RoRServerBot/wiki/Configuration) and a [commands list](https://github.com/tritonas00/RoRServerBot/wiki/Commands).
+An in-depth installation guide can be found on the [Wiki](https://github.com/CuriousMike56/RoRServerBot/wiki), along with a [configuration guide](https://github.com/CuriousMike56/RoRServerBot/wiki/Configuration) and a [commands list](https://github.com/CuriousMike56/RoRServerBot/wiki/Commands).
 
 # Credits
 

--- a/RoR_client.py
+++ b/RoR_client.py
@@ -64,19 +64,20 @@ playerColours = [
         "#999900"
 ];
 
-# Name may be in "bname:fname.truck" format, where 'bundle' is ZIP/subdir in modcache. See https://github.com/RigsOfRods/rigs-of-rods/pull/3171
+# Stream names may be in "bundle:filename.truck" format, where the bundle
+# is the ZIP/subdirectory in modcache. This preserves upstream support for
+# Rigs of Rods stream names introduced around PR #3171.
 def getTruckFilenameFromStreamName(streamName):
+    streamName = b(streamName)
     if b':' in streamName:
-        return streamName.split(b':')[1]
-    else:
-        return streamName
-        
-# Name may be in "bname:fname.truck" format, where 'bundle' is ZIP/subdir in modcache. See https://github.com/RigsOfRods/rigs-of-rods/pull/3171
+        return streamName.split(b':', 1)[1]
+    return streamName
+
 def getTruckBundleNameFromStreamName(streamName):
+    streamName = b(streamName)
     if b':' in streamName:
-        return streamName.split(b':')[0]
-    else:
-        return streamName
+        return streamName.split(b':', 1)[0]
+    return b''
 
 def getTruckName(filename):
     if filename in TruckToName.list:
@@ -93,7 +94,7 @@ def getTruckInfo(streamName):
             'type': getTruckType(filename),
             'name': getTruckName(filename),
             'file': filename,
-            'bundle':bundlename
+            'bundle': bundlename,
     }
 
 class interruptReceived(Exception):
@@ -485,8 +486,11 @@ class Discord_Layer:
     # [game] <username> is now driving a <truckname> (streams: <number of streams>/<limit of streams>)
     def sayStreamReg(self, uid, stream):
         truckinfo =  getTruckInfo(stream.name);
-        banned = self.main.isVehicleBanned(s(truckinfo['file']))
-        if banned:
+        if hasattr(self.main, 'isVehicleBanned'):
+            invalid = self.main.isVehicleBanned(s(truckinfo['file']))
+        else:
+            invalid = self.main.validate(s(truckinfo['file']))
+        if invalid:
             self.sayInfo("User **%s** with uid **%s** has spawned a **%s** which is a banned vehicle." % (self.sm.getUsername(uid), uid, s(truckinfo['file'])))
             self.main.queueKick(self.channelID, int(uid))
         else:
@@ -710,6 +714,10 @@ class RoR_Connection:
 
         if packet is None:
             self.logger.critical("Server sent nothing, while it should have sent us a welcome message.")
+            try:
+                self.disconnect()
+            except Exception:
+                pass
             return False
 
         # Some error handling
@@ -747,7 +755,7 @@ class RoR_Connection:
         s.type = TYPE_CHARACTER
         s.status = 0
         s.regdata = chr(2)
-        print("stream default: %d" % self.registerStream(s))
+        self.registerStream(s)
 
         # register chat stream
         s = stream_info_t()
@@ -755,7 +763,7 @@ class RoR_Connection:
         s.type = TYPE_CHAT
         s.status = 0
         s.regdata = 0
-        print("stream chat: %d" % self.registerStream(s))
+        self.registerStream(s)
 
         # set the time when we connected (needed to send stream data)
         self.connectTime = time.time()
@@ -768,11 +776,32 @@ class RoR_Connection:
     def disconnect(self):
         self.logger.info("Disconnecting...")
         self.runCondition = 0
-        time.sleep(5)
-        if not self.socket is None:
-            self.__sendUserLeave()
-            print('closing socket')
-            self.socket.close()
+
+        if self.socket is not None:
+            try:
+                self.__sendUserLeave()
+            except Exception as e:
+                self.logger.debug("Unable to send user leave during disconnect: %s", e)
+
+            try:
+                server_label = "unknown server"
+
+                if hasattr(self, "serverinfo"):
+                    if getattr(self.serverinfo, "servername", None):
+                        server_label = s(self.serverinfo.servername)
+                    elif getattr(self.serverinfo, "host", None) and getattr(self.serverinfo, "port", None):
+                        server_label = "%s:%s" % (self.serverinfo.host, self.serverinfo.port)
+
+                print("Closing connection to server '%s'" % server_label)
+                self.socket.shutdown(socket.SHUT_RDWR)
+            except Exception:
+                pass
+
+            try:
+                self.socket.close()
+            except Exception:
+                pass
+
         self.socket = None
 
     # Internal use only!
@@ -957,21 +986,44 @@ class RoR_Connection:
         if self.socket is None:
             return False
 
-        try:
-            #print data
-            if data is None:
-                return
+        if data is None:
+            return False
 
-            self.socket.send(data)
-        except Exception as e:
-            self.logger.exception('sendMsg error: '+str(e))
+        try:
+            # sendall() ensures the full packet is written or raises an error.
+            self.socket.sendall(data)
+            return True
+
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError) as e:
+            self.logger.warning("sendMsg failed because the RoR socket disconnected: %s", e)
+
+            try:
+                self.socket.close()
+            except Exception:
+                pass
+
+            # This makes Client.bigLoop() exit; Client.run() already handles reconnecting.
+            self.socket = None
             self.runCondition = 0
-            # import traceback
-            # traceback.print_exc(file=sys.stdout)
-        return True
+            return False
+
+        except Exception as e:
+            self.logger.exception('sendMsg error: ' + str(e))
+            self.runCondition = 0
+            return False
 
     # Internal use only!
     def __packPacket(self, packet):
+        if packet.command < 0 or packet.source < 0 or packet.streamid < 0 or packet.size < 0:
+            self.logger.warning(
+                "Skipping invalid packet with negative value: command=%s source=%s streamid=%s size=%s",
+                packet.command,
+                packet.source,
+                packet.streamid,
+                packet.size
+            )
+            return None
+
         if packet.size == 0:
             # just header
             data = struct.pack('IIII', packet.command, packet.source, packet.streamid, packet.size)
@@ -1019,18 +1071,22 @@ class RoR_Connection:
                     if not tmp:
                         errorCount += 1;
                         if errorCount > 3:
-                            # lost connection
-                            self.logger.error("Connection error #ERROR_CON005")
-                            self.runCondition = 0
+                            if not self.runCondition:
+                                self.logger.info("Receive thread noticed clean shutdown.")
+                            else:
+                                self.logger.error("Connection error #ERROR_CON005")
+                                self.runCondition = 0
                             break
                         continue
                     else:
                         data += tmp
 
                 if not data or errorCount > 3:
-                    # lost connection
-                    self.logger.error("Connection error #ERROR_CON008")
-                    self.runCondition = 0
+                    if not self.runCondition:
+                        self.logger.info("Receive thread noticed clean shutdown.")
+                    else:
+                        self.logger.error("Connection error #ERROR_CON008")
+                        self.runCondition = 0
                     break
 
                 (command, source, streamid, size) = struct.unpack('IIII', data)
@@ -1049,23 +1105,30 @@ class RoR_Connection:
                     if not tmp:
                         errorCount += 1;
                         if errorCount > 3:
-                            # lost connection
-                            self.logger.error("Connection error #ERROR_CON006")
-                            self.runCondition = 0
+                            if not self.runCondition:
+                                self.logger.info("Receive thread noticed clean shutdown.")
+                            else:
+                                self.logger.error("Connection error #ERROR_CON006")
+                                self.runCondition = 0
                             break
                         continue
                     else:
                         data += tmp
             except socket.error:
-                self.logger.error("Connection error #ERROR_CON015")
-                self.runCondition = 0
+                if not self.runCondition:
+                    self.logger.info("Receive thread noticed clean shutdown.")
+                else:
+                    self.logger.error("Connection error #ERROR_CON015")
+                    self.runCondition = 0
                 break
 
             if command != MSG2_STREAM_UNREGISTER: # No data
                 if not data or errorCount > 3:
-                    # lost connection
-                    self.logger.error("Connection error #ERROR_CON007")
-                    self.runCondition = 0
+                    if not self.runCondition:
+                        self.logger.info("Receive thread noticed clean shutdown.")
+                    else:
+                        self.logger.error("Connection error #ERROR_CON007")
+                        self.runCondition = 0
                     break
 
             content = struct.unpack(str(size) + 's', data)[0]
@@ -1074,7 +1137,10 @@ class RoR_Connection:
                 self.logger.debug("R<| %-18s %03d:%02d (%d)" % (commandName(command), source, streamid, size))
 
             self.receivedMessages.put(DataPacket(command, source, streamid, size, content))
-        self.logger.warning("Receive thread exiting...")
+        if self.runCondition:
+            self.logger.warning("Receive thread exiting unexpectedly...")
+        else:
+            self.logger.info("Receive thread exited cleanly.")
 
     def setNetQuality(self, quality):
         if self.netQuality != quality:
@@ -1170,6 +1236,7 @@ class Client(threading.Thread):
         serverinfo.host      = self.main.settings.getSetting('RoRclients', self.ID, 'host')
         serverinfo.port      = self.main.settings.getSetting('RoRclients', self.ID, 'port')
         serverinfo.password  = self.main.settings.getSetting('RoRclients', self.ID, 'password')
+        serverinfo.protocolversion = self.main.settings.getSetting('RoRclients', self.ID, 'protocolversion')
         serverinfo.pasworded = len(serverinfo.password)!=0
 
         # try to connect to the server

--- a/configuration-example.xml
+++ b/configuration-example.xml
@@ -4,7 +4,8 @@
 	It's really easy, if you can host a RoR-server, host this bot,
 	then I assume that you can read/write XML as well.
 	
-	There're 2 sections in this file:
+	There're 3 sections in this file:
+	  - The general configuration with soEme general stuff in it
 	  - The Discord configuration
 	  - The RoR-server(s) configuration
 	Quite self-explanatory.
@@ -12,34 +13,74 @@
 	Minimal configuration:
 		<configuration>
 			<Discordclient>
-				<bot token="" />
+				<bot token="PUT_DISCORD_BOT_TOKEN_HERE" />
 			</Discordclient>
 			<RoRclients>
 				<RoRclient>
-					<server host="yourHost" port=somePort />
-					<discord channel="" />
+					<server host="SERVER_IP_OR_HOSTNAME" port=somePort />
+					<discord channel="PUT_DISCORD_CHANNEL_ID_HERE" />
 				</RoRclient>
 			</RoRclients>
 		</configuration>
  -->
 <configuration>
 
+	<general>
+		<version>2022.12</version>
+		<fullversion>2022.12</fullversion>
+		<logfile append="yes" level="debug">RoRservices.log</logfile> <!-- that doesn't work -->
+	</general>
+
 	<Discordclient>
-		<bot token="" />
+		<bot token="PUT_DISCORD_BOT_TOKEN_HERE" />
 	</Discordclient>
 	
 	<RoRclients>
-		<RoRclient id="myServer1" enabled="yes">
-			<server host="example.com" port="12000" password="" />
-			<user name="Services" token="515cf64ec28c445ca5786ec7122d7154" language="en_US" />
-			<!-- Copy and paste the channel ID here. To get the channel ID you must first enter 
-			Developer Mode from User Settings -> Appearance -> Advanced -> and toggle on/off
-			for Developer Mode -->
-			<discord channel="" />
-			<announcements delay="600" enabled="yes"> <!-- delay in seconds -->
-				<announcement>Hi, I'm an announcement</announcement>
-				<announcement>And I'm the second announcement.</announcement>
-				<announcement>And I'm the last one. After me, you'll see number 1 again</announcement>
+		<RoRclient id="default/template" enabled="no">
+            <server password="" />
+            <user name="Services" token="PUT_DISCORD_BOT_TOKEN_HERE" language="en_US" />
+            <announcements delay="2700" enabled="yes"> <!-- delay in seconds -->
+				<announcement>#0101DFWelcome to Example Community!</announcement>
+				<announcement>#0101DFMake sure to check us out at example.com!</announcement>
+				<announcement>#0101DFThis server is sponsored by Example Community.</announcement>
+            </announcements>
+        </RoRclient>
+		
+		<RoRclient id="Server1" enabled="yes">
+			<server host="SERVER_IP_OR_HOSTNAME" port="12720" password="" protocolversion="RoRnet_2.45" />
+			<user name="Services" token="PUT_DISCORD_BOT_TOKEN_HERE" language="en_US" />
+			<discord channel="PUT_DISCORD_CHANNEL_ID_HERE" />
+			<announcements delay="2700" enabled="no"> <!-- delay in seconds -->
+            </announcements>
+		</RoRclient>
+		
+		<RoRclient id="Example_Any" enabled="yes">
+			<server host="SERVER_IP_OR_HOSTNAME" port="12721" password="" protocolversion="RoRnet_2.44" />
+			<user name="Services" token="PUT_DISCORD_BOT_TOKEN_HERE" language="en_US" />
+			<discord channel="PUT_DISCORD_CHANNEL_ID_HERE" />
+			<announcements delay="1800" enabled="yes"> <!-- delay in seconds -->
+				<announcement>#0101DFWelcome to Example Community!</announcement>
+				<announcement>#0101DFMake sure to check us out at example.com!</announcement>
+				<announcement>#0101DFPlease make sure to check and obide by our rules! Use !rules to view them.</announcement>
+			</announcements>
+		</RoRclient>
+		
+		<RoRclient id="Server2" enabled="yes">
+			<server host="SERVER_IP_OR_HOSTNAME" port="12000" password="" protocolversion="RoRnet_2.44" />
+			<user name="Services" token="PUT_DISCORD_BOT_TOKEN_HERE" language="en_US" />
+			<discord channel="PUT_DISCORD_CHANNEL_ID_HERE" />
+			<announcements delay="1800" enabled="yes"> <!-- delay in seconds -->
+				<announcement>#0101DFThis server is sponsored by Example Community.</announcement>
+				<announcement>#0101DFCheck out Example Community at example.com</announcement>
+			</announcements>
+		</RoRclient>
+		
+		<RoRclient id="Server3" enabled="yes">
+			<server host="SERVER_IP_OR_HOSTNAME" port="12448" password="" protocolversion="RoRnet_2.45" />
+			<user name="Services" token="PUT_DISCORD_BOT_TOKEN_HERE" language="en_US" />
+			<discord channel="PUT_DISCORD_CHANNEL_ID_HERE" />
+			<announcements delay="1800" enabled="yes"> <!-- delay in seconds -->
+				<announcement>This server is sponsored by Example Community.</announcement>
 			</announcements>
 		</RoRclient>
 	</RoRclients>

--- a/services_start.py
+++ b/services_start.py
@@ -62,6 +62,7 @@ class Config:
                 'host': None,
                 'port': 0,
                 'password': '',
+                'protocolversion': 'RoRnet_2.45',
 
                 'username': 'services',
                 'usertoken': '',
@@ -174,6 +175,7 @@ class Config:
             s['host']     = RoRclient.find("./server").get("host", default=s['host'])
             s['port'] = int(RoRclient.find("./server").get("port", default=s['port']))
             s['password'] = RoRclient.find("./server").get("password", default=s['password'])
+            s['protocolversion'] = RoRclient.find("./server").get("protocolversion", default=RoRclient.find("./server").get("protocol", default=s['protocolversion']))
         if ( s['host'] is None or s['port']==0 ) and ID != "default/template":
             self.logger.error("configuration/RoRclients/RoRclient(%s)/server[@host, @port] needs to be set!", ID)
             self.logger.error("Ignoring RoRclient(%s)", ID)
@@ -318,6 +320,9 @@ class Main(discord.Client):
                 self.RoRclients[ID].start()
 
     def isVehicleBanned(self, truck):
+        return self.validate(truck)
+
+    def validate(self, truck):
         if os.path.isfile('truck.blacklist') == False:
             return False
 


### PR DESCRIPTION
## Summary

This pull request adds per-server RoRNet protocol configuration while keeping `RoRnet_2.45` as the default protocol.

It also includes several connection stability, socket handling, disconnect cleanup, and console-output improvements. The goal is to make RoRBot behave more reliably during normal operation, failed handshakes, server disconnects, and intentional shutdowns, while still supporting both current and legacy RoR server versions.

## Main changes

### Per-server RoRNet protocol configuration

The bot now supports setting the RoRNet protocol version per configured server.

The default remains:

```xml
RoRnet_2.45
```

This matches the current upstream default.

Individual server entries can override the protocol with either:

```xml
protocolversion="RoRnet_2.44"
```

or:

```xml
protocol="RoRnet_2.44"
```

This allows mixed deployments where the same bot instance may connect to both RoR 2.45 and legacy RoR 2.44 servers.

Examples:

```xml
<server host="127.0.0.1" port="12000" password="" />
```

Uses the default `RoRnet_2.45`.

```xml
<server host="127.0.0.1" port="12001" password="" protocolversion="RoRnet_2.45" />
```

Explicitly uses `RoRnet_2.45`.

```xml
<server host="127.0.0.1" port="12002" password="" protocolversion="RoRnet_2.44" />
```

Uses legacy `RoRnet_2.44`.

### Protocol value is passed into the handshake

The configured protocol value is now assigned to the server info before the bot sends the initial hello packet.

This means the protocol setting is not just read from the config, it is actually used during the RoRNet connection handshake.

### Safer failed-handshake cleanup

If the bot connects to a server but does not receive the expected welcome packet, it now attempts to disconnect cleanly before returning failure.

Previously, this path could leave the socket in a half-open or dirty state. Cleaning it up before returning makes reconnect behavior safer and easier to reason about.

### Removed forced disconnect delay

The disconnect logic no longer waits on a hard-coded delay before closing the socket.

This makes intentional shutdowns and restarts faster and avoids unnecessary waiting after the bot has already been told to disconnect.

### Safer socket disconnect handling

Disconnect handling now catches errors when the socket is already closed, reset, or otherwise unavailable.

The updated disconnect flow:

* Stops the receive loop.
* Attempts to send the user-leave packet.
* Ignores that failure if the socket is already gone.
* Attempts a socket shutdown.
* Attempts a socket close.
* Clears the socket reference afterward.

This prevents normal disconnects from turning into unnecessary traceback-style socket errors.

### Replaced `socket.send()` with `socket.sendall()`

Raw packet sending now uses `sendall()` instead of `send()`.

This is safer for RoRNet packets because `send()` is not guaranteed to transmit the entire buffer in one call. Since RoRNet packets have strict binary headers and payload sizes, partial sends can cause unreliable behavior.

### Broken socket handling during send operations

The send path now catches common disconnect-related socket errors, including:

```python
BrokenPipeError
ConnectionResetError
ConnectionAbortedError
OSError
```

When one of these occurs, the bot:

* Logs the failure as a socket disconnect.
* Attempts to close the socket.
* Clears the socket reference.
* Stops the active connection loop.
* Allows the existing reconnect logic to take over.

This prevents the bot from continuing to run against a dead socket.

### Guard against invalid packet values

Packet packing now checks for invalid negative values before calling `struct.pack()`.

This protects fields such as:

* `command`
* `source`
* `streamid`
* `size`

RoRNet packet headers are packed as unsigned integers, so negative values should be skipped instead of causing a packing failure.

### Guard against sending `None` packet data

If packet packing fails and returns `None`, the raw send method now safely returns instead of trying to send invalid data.

This prevents one packet error from cascading into a second socket error.

### Cleaner console output for stream registration

The startup debug-style prints for stream registration were removed.

Previously, the bot could print messages like:

```text
stream default: 10
stream chat: 11
```

These values are not errors, they are just internal stream IDs. Removing them keeps console output cleaner and less confusing.

### Clearer disconnect console output

The generic message:

```text
closing socket
```

was replaced with clearer server-specific output, such as:

```text
Closing connection to server 'Example Server Name'
```

If the server name is unavailable, the code falls back to host/port or a generic server label.

This is more useful when one bot process is connected to multiple servers.

### Reduced misleading connection-error logs during intentional shutdowns

The receive thread now better distinguishes between an unexpected connection failure and an intentional shutdown.

Previously, normal shutdowns could produce misleading errors such as:

```text
Connection error #ERROR_CON005
Connection error #ERROR_CON006
Connection error #ERROR_CON007
Connection error #ERROR_CON008
Connection error #ERROR_CON015
```

Those messages can still appear for real connection problems, but intentional shutdowns should no longer be logged as if they were unexpected network failures.

### Cleaner receive-thread exit logging

The receive thread now logs cleaner messages depending on whether it exited because of a normal shutdown or because of a connection problem.

This makes troubleshooting easier because normal stops and real connection failures are easier to tell apart.

### Preserved upstream vehicle stream-name parsing

The existing upstream vehicle stream-name parsing behavior is preserved, including support for stream names using the newer format:

```text
bundle:filename.truck
```

The helper logic was also made safer so vehicle stream parsing can handle both `bytes` and `str` values.

This prevents issues in vehicle name display, banned-vehicle checks, and Discord/game bridge messages when different code paths provide stream names in different formats.

## Why this is useful

This change is useful for deployments that need to support both current and older RoR servers.

Keeping `RoRnet_2.45` as the default makes sense for current upstream behavior, but allowing per-server overrides avoids forcing every configured server to use the same protocol.

The socket and shutdown changes also make the bot more reliable and easier to troubleshoot. They reduce noisy or misleading console output, improve behavior when a server disconnects unexpectedly, and make intentional shutdowns look intentional instead of like connection failures.

## Testing performed

Static verification was completed:

* `RoR_client.py` compiles.
* `RoRnet.py` compiles.
* `services_start.py` compiles.
* `TruckToName.py` compiles.
* `RoR_client.py` imports successfully.
* Vehicle stream parsing works with plain filenames.
* Vehicle stream parsing works with `bundle:filename.truck`.
* Vehicle stream parsing works with both `bytes` and `str` input.
