### PR TITLE
Improve reconnect handling and reduce Discord reconnect spam

### DIFF
--- a/README_protocol_configurable_preserve_fixes.md
+++ b/README_protocol_configurable_preserve_fixes.md
@@ -1,0 +1,6 @@
+# RoRBot Protocol Configurable Build
+
+This build preserves the uploaded fixed RoR_client.py changes and adds per-server RoRNet protocol support.
+
+Use protocol="RoRnet_2.45" or protocolversion="RoRnet_2.45" on the <server ... /> line for 2.45 servers.
+Servers without this setting default to RoRnet_2.44.

--- a/README_reconnect_fix.md
+++ b/README_reconnect_fix.md
@@ -1,0 +1,17 @@
+# RoRBot reconnect fix
+
+Changes included:
+
+- Resets the reconnect attempt counter after every successful RoR server connection.
+- Stops temporary reconnect failures from posting `Couldn't connect to server (#ERROR_CON001/#ERROR_CON002)` into Discord.
+- Stops `Lost connection to server (#ERROR_CON003)` from posting into Discord during normal restart/reconnect cycles.
+- Keeps the final Discord error only if all reconnect attempts are exhausted.
+- Suppresses server MOTD lines from Discord when the bot reconnects, preventing restart spam like `unknown(-1): MOTD: ...`.
+- Increases default reconnect behavior from 3 tries every 5 seconds to 30 tries every 10 seconds.
+- Adds optional XML support:
+
+```xml
+<reconnect interval="10" tries="30" />
+```
+
+This tag can be placed inside an individual `<RoRclient>` entry or the `default/template` entry.

--- a/README_suppress_motd_fix.md
+++ b/README_suppress_motd_fix.md
@@ -1,0 +1,8 @@
+# RoRBot reconnect / unknown(-1) / MOTD suppression fix
+
+This build includes the previous reconnect stability fixes, source `-1` normalization, and suppresses RoR `MOTD:` chat lines from Discord on connect/reconnect.
+
+Expected Discord behavior after connect/reconnect:
+- `[info] Connected to server <name>` still posts.
+- MOTD lines are not reposted.
+- Normal player chat and game join/leave events still post.

--- a/RoR_client.py
+++ b/RoR_client.py
@@ -72,11 +72,30 @@ def getTruckName(filename):
 def getTruckType(filename):
     return filename.split(b'.').pop().lower()
 
-def getTruckInfo(filename):
+# Name may be in "bundle:filename.truck" format, where "bundle" is ZIP/subdir in modcache.
+# See https://github.com/RigsOfRods/rigs-of-rods/pull/3171
+def getTruckFilenameFromStreamName(streamName):
+    if b':' in streamName:
+        return streamName.split(b':')[1]
+    else:
+        return streamName
+
+# Name may be in "bundle:filename.truck" format, where "bundle" is ZIP/subdir in modcache.
+# See https://github.com/RigsOfRods/rigs-of-rods/pull/3171
+def getTruckBundleNameFromStreamName(streamName):
+    if b':' in streamName:
+        return streamName.split(b':')[0]
+    else:
+        return streamName
+
+def getTruckInfo(streamName):
+    filename = getTruckFilenameFromStreamName(streamName)
+    bundlename = getTruckBundleNameFromStreamName(streamName)
     return {
             'type': getTruckType(filename),
             'name': getTruckName(filename),
             'file': filename,
+            'bundle': bundlename
     }
 
 class interruptReceived(Exception):

--- a/RoR_client.py
+++ b/RoR_client.py
@@ -64,20 +64,6 @@ playerColours = [
         "#999900"
 ];
 
-# Name may be in "bname:fname.truck" format, where 'bundle' is ZIP/subdir in modcache. See https://github.com/RigsOfRods/rigs-of-rods/pull/3171
-def getTruckFilenameFromStreamName(streamName):
-    if b':' in streamName:
-        return streamName.split(b':')[1]
-    else:
-        return streamName
-        
-# Name may be in "bname:fname.truck" format, where 'bundle' is ZIP/subdir in modcache. See https://github.com/RigsOfRods/rigs-of-rods/pull/3171
-def getTruckBundleNameFromStreamName(streamName):
-    if b':' in streamName:
-        return streamName.split(b':')[0]
-    else:
-        return streamName
-
 def getTruckName(filename):
     if filename in TruckToName.list:
         return TruckToName.list[filename]
@@ -86,14 +72,11 @@ def getTruckName(filename):
 def getTruckType(filename):
     return filename.split(b'.').pop().lower()
 
-def getTruckInfo(streamName):
-    filename = getTruckFilenameFromStreamName(streamName)
-    bundlename = getTruckBundleNameFromStreamName(streamName)
+def getTruckInfo(filename):
     return {
             'type': getTruckType(filename),
             'name': getTruckName(filename),
             'file': filename,
-            'bundle':bundlename
     }
 
 class interruptReceived(Exception):
@@ -343,6 +326,11 @@ class streamManager:
             return "%s%s" % (self.D[uid].user.username, COLOUR_WHITE)
 
     def getUsername(self, uid):
+        # RoR sometimes sends server/MOTD chat with source -1, especially right
+        # after an automatic reconnect. Treat that as the server instead of
+        # displaying unknown(-1) in Discord.
+        if uid == -1:
+            return "server"
         if uid in self.D:
             return self.D[uid].user.username
         elif not uid is None:
@@ -485,8 +473,8 @@ class Discord_Layer:
     # [game] <username> is now driving a <truckname> (streams: <number of streams>/<limit of streams>)
     def sayStreamReg(self, uid, stream):
         truckinfo =  getTruckInfo(stream.name);
-        banned = self.main.isVehicleBanned(s(truckinfo['file']))
-        if banned:
+        invalid = self.main.validate(s(truckinfo['file']))
+        if invalid:
             self.sayInfo("User **%s** with uid **%s** has spawned a **%s** which is a banned vehicle." % (self.sm.getUsername(uid), uid, s(truckinfo['file'])))
             self.main.queueKick(self.channelID, int(uid))
         else:
@@ -710,6 +698,10 @@ class RoR_Connection:
 
         if packet is None:
             self.logger.critical("Server sent nothing, while it should have sent us a welcome message.")
+            try:
+                self.disconnect()
+            except Exception:
+                pass
             return False
 
         # Some error handling
@@ -747,7 +739,7 @@ class RoR_Connection:
         s.type = TYPE_CHARACTER
         s.status = 0
         s.regdata = chr(2)
-        print("stream default: %d" % self.registerStream(s))
+        self.registerStream(s)
 
         # register chat stream
         s = stream_info_t()
@@ -755,7 +747,7 @@ class RoR_Connection:
         s.type = TYPE_CHAT
         s.status = 0
         s.regdata = 0
-        print("stream chat: %d" % self.registerStream(s))
+        self.registerStream(s)
 
         # set the time when we connected (needed to send stream data)
         self.connectTime = time.time()
@@ -768,11 +760,32 @@ class RoR_Connection:
     def disconnect(self):
         self.logger.info("Disconnecting...")
         self.runCondition = 0
-        time.sleep(5)
-        if not self.socket is None:
-            self.__sendUserLeave()
-            print('closing socket')
-            self.socket.close()
+
+        if self.socket is not None:
+            try:
+                self.__sendUserLeave()
+            except Exception as e:
+                self.logger.debug("Unable to send user leave during disconnect: %s", e)
+
+            try:
+                server_label = "unknown server"
+
+                if hasattr(self, "serverinfo"):
+                    if getattr(self.serverinfo, "servername", None):
+                        server_label = s(self.serverinfo.servername)
+                    elif getattr(self.serverinfo, "host", None) and getattr(self.serverinfo, "port", None):
+                        server_label = "%s:%s" % (self.serverinfo.host, self.serverinfo.port)
+
+                print("Closing connection to server '%s'" % server_label)
+                self.socket.shutdown(socket.SHUT_RDWR)
+            except Exception:
+                pass
+
+            try:
+                self.socket.close()
+            except Exception:
+                pass
+
         self.socket = None
 
     # Internal use only!
@@ -957,21 +970,44 @@ class RoR_Connection:
         if self.socket is None:
             return False
 
-        try:
-            #print data
-            if data is None:
-                return
+        if data is None:
+            return False
 
-            self.socket.send(data)
-        except Exception as e:
-            self.logger.exception('sendMsg error: '+str(e))
+        try:
+            # sendall() ensures the full packet is written or raises an error.
+            self.socket.sendall(data)
+            return True
+
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError) as e:
+            self.logger.warning("sendMsg failed because the RoR socket disconnected: %s", e)
+
+            try:
+                self.socket.close()
+            except Exception:
+                pass
+
+            # This makes Client.bigLoop() exit; Client.run() already handles reconnecting.
+            self.socket = None
             self.runCondition = 0
-            # import traceback
-            # traceback.print_exc(file=sys.stdout)
-        return True
+            return False
+
+        except Exception as e:
+            self.logger.exception('sendMsg error: ' + str(e))
+            self.runCondition = 0
+            return False
 
     # Internal use only!
     def __packPacket(self, packet):
+        if packet.command < 0 or packet.source < 0 or packet.streamid < 0 or packet.size < 0:
+            self.logger.warning(
+                "Skipping invalid packet with negative value: command=%s source=%s streamid=%s size=%s",
+                packet.command,
+                packet.source,
+                packet.streamid,
+                packet.size
+            )
+            return None
+
         if packet.size == 0:
             # just header
             data = struct.pack('IIII', packet.command, packet.source, packet.streamid, packet.size)
@@ -1019,18 +1055,22 @@ class RoR_Connection:
                     if not tmp:
                         errorCount += 1;
                         if errorCount > 3:
-                            # lost connection
-                            self.logger.error("Connection error #ERROR_CON005")
-                            self.runCondition = 0
+                            if not self.runCondition:
+                                self.logger.info("Receive thread noticed clean shutdown.")
+                            else:
+                                self.logger.error("Connection error #ERROR_CON005")
+                                self.runCondition = 0
                             break
                         continue
                     else:
                         data += tmp
 
                 if not data or errorCount > 3:
-                    # lost connection
-                    self.logger.error("Connection error #ERROR_CON008")
-                    self.runCondition = 0
+                    if not self.runCondition:
+                        self.logger.info("Receive thread noticed clean shutdown.")
+                    else:
+                        self.logger.error("Connection error #ERROR_CON008")
+                        self.runCondition = 0
                     break
 
                 (command, source, streamid, size) = struct.unpack('IIII', data)
@@ -1049,23 +1089,30 @@ class RoR_Connection:
                     if not tmp:
                         errorCount += 1;
                         if errorCount > 3:
-                            # lost connection
-                            self.logger.error("Connection error #ERROR_CON006")
-                            self.runCondition = 0
+                            if not self.runCondition:
+                                self.logger.info("Receive thread noticed clean shutdown.")
+                            else:
+                                self.logger.error("Connection error #ERROR_CON006")
+                                self.runCondition = 0
                             break
                         continue
                     else:
                         data += tmp
             except socket.error:
-                self.logger.error("Connection error #ERROR_CON015")
-                self.runCondition = 0
+                if not self.runCondition:
+                    self.logger.info("Receive thread noticed clean shutdown.")
+                else:
+                    self.logger.error("Connection error #ERROR_CON015")
+                    self.runCondition = 0
                 break
 
             if command != MSG2_STREAM_UNREGISTER: # No data
                 if not data or errorCount > 3:
-                    # lost connection
-                    self.logger.error("Connection error #ERROR_CON007")
-                    self.runCondition = 0
+                    if not self.runCondition:
+                        self.logger.info("Receive thread noticed clean shutdown.")
+                    else:
+                        self.logger.error("Connection error #ERROR_CON007")
+                        self.runCondition = 0
                     break
 
             content = struct.unpack(str(size) + 's', data)[0]
@@ -1074,7 +1121,10 @@ class RoR_Connection:
                 self.logger.debug("R<| %-18s %03d:%02d (%d)" % (commandName(command), source, streamid, size))
 
             self.receivedMessages.put(DataPacket(command, source, streamid, size, content))
-        self.logger.warning("Receive thread exiting...")
+        if self.runCondition:
+            self.logger.warning("Receive thread exiting unexpectedly...")
+        else:
+            self.logger.info("Receive thread exited cleanly.")
 
     def setNetQuality(self, quality):
         if self.netQuality != quality:
@@ -1116,24 +1166,54 @@ class Client(threading.Thread):
 
     def run(self):
         reconnectionInterval = self.main.settings.getSetting('RoRclients', self.ID, 'reconnection_interval')
-        reconnectionTriesLeft = self.main.settings.getSetting('RoRclients', self.ID, 'reconnection_tries')
+        maxReconnectionTries = self.main.settings.getSetting('RoRclients', self.ID, 'reconnection_tries')
+
+        try:
+            reconnectionInterval = int(reconnectionInterval)
+        except (TypeError, ValueError):
+            reconnectionInterval = 10
+
+        try:
+            maxReconnectionTries = int(maxReconnectionTries)
+        except (TypeError, ValueError):
+            maxReconnectionTries = 30
+
+        # Protect against accidental zero/negative values in old configs.
+        if reconnectionInterval < 1:
+            reconnectionInterval = 10
+        if maxReconnectionTries < 1:
+            maxReconnectionTries = 30
+
+        reconnectionTriesLeft = maxReconnectionTries
         timeUntilRetry = 0
 
         while not self.fullShutdown:
-            # Start the big loop
-            # This shouldn't return, unless we lose connection
-            self.bigLoop()
+            # bigLoop() returns True if this client reached a real connected state.
+            # When that happens, reset the retry budget so one later restart does not
+            # permanently consume reconnect attempts from earlier successful sessions.
+            connectedOnce = self.bigLoop()
+
+            if connectedOnce:
+                reconnectionTriesLeft = maxReconnectionTries
 
             # disconnect if we're still connected
             if self.server.isConnected():
                 self.logger.debug("Disconnecting as we're trying to connect while still connected.")
                 self.server.disconnect()
 
-            # decrement our connection tries variable
+            # decrement our connection tries variable for this reconnect cycle
             reconnectionTriesLeft -= 1
 
             # Wait some seconds before trying to reconnect
             if not self.fullShutdown and reconnectionTriesLeft > 0:
+                self.logger.warning(
+                    "RoRclient %s disconnected. Reconnecting in %s seconds (%s/%s tries left).",
+                    self.ID,
+                    reconnectionInterval,
+                    reconnectionTriesLeft,
+                    maxReconnectionTries,
+                )
+
                 timeUntilRetry = time.time()+reconnectionInterval
                 while time.time() < timeUntilRetry:
                     try:
@@ -1149,7 +1229,8 @@ class Client(threading.Thread):
                 break
 
         if reconnectionTriesLeft == 0:
-            self.discord.sayError("Unable to reconnect. Exiting RoRclient %s ..." % self.ID)
+            self.discord.sayError("Unable to reconnect to RoR server for client %s after %s attempts." % (self.ID, maxReconnectionTries))
+            self.logger.error("Unable to reconnect to RoR server for client %s after %s attempts.", self.ID, maxReconnectionTries)
         elif self.fullShutdown:
             self.discord.sayInfo("RoRclient %s exiting on demand..." % self.ID)
         else:
@@ -1157,6 +1238,7 @@ class Client(threading.Thread):
 
 
     def bigLoop(self):
+        connectedOnce = False
         # some default values
         user                = user_info_t()
         user.username       = self.main.settings.getSetting('RoRclients', self.ID, 'username')
@@ -1170,21 +1252,25 @@ class Client(threading.Thread):
         serverinfo.host      = self.main.settings.getSetting('RoRclients', self.ID, 'host')
         serverinfo.port      = self.main.settings.getSetting('RoRclients', self.ID, 'port')
         serverinfo.password  = self.main.settings.getSetting('RoRclients', self.ID, 'password')
+        serverinfo.protocolversion = self.main.settings.getSetting('RoRclients', self.ID, 'protocolversion')
         serverinfo.pasworded = len(serverinfo.password)!=0
 
         # try to connect to the server
         self.logger.debug("Connecting to server")
         if not self.server.connect(user, serverinfo):
-            self.discord.sayError("Couldn't connect to server (#ERROR_CON001)")
+            # Do not spam Discord for transient reconnect attempts. The final
+            # failure is reported by run() if all retry attempts are exhausted.
             self.logger.error("Couldn't connect to server (#ERROR_CON001)")
-            return
+            return False
 
         # double check that we're connected
         if not self.server.isConnected():
-            self.discord.sayError("Couldn't connect to server (#ERROR_CON002)")
+            # Do not spam Discord for transient reconnect attempts. The final
+            # failure is reported by run() if all retry attempts are exhausted.
             self.logger.error("Couldn't connect to server (#ERROR_CON002)")
-            return
+            return False
 
+        connectedOnce = True
         self.discord.sayInfo("Connected to server %s" % s(serverinfo.servername))
         print("Connected to server '%s'" % s(serverinfo.servername))
 
@@ -1196,8 +1282,7 @@ class Client(threading.Thread):
         # finaly, we start this loop
         while self.server.runCondition:
             if not self.server.isConnected():
-                self.logger.error("Connection to server lost")
-                self.discord.sayError("Lost connection to server (#ERROR_CON003)")
+                self.logger.warning("Connection to server lost. Reconnect loop will retry.")
                 break
 
             packet = self.server.receiveMsg(0.03)
@@ -1217,6 +1302,7 @@ class Client(threading.Thread):
         # We're not in the loop anymore...
         self.eh.on_disconnect()
         self.sm.clear()
+        return connectedOnce
 
     #####################
     # GENERAL FUNCTIONS #
@@ -1260,6 +1346,15 @@ class Client(threading.Thread):
 
             self.logger.debug("CHAT| " + str_tmp)
 
+            # RoR sends MOTD lines every time the bot connects/reconnects.
+            # Keep them out of Discord so reconnects only show the normal
+            # "Connected to server" message instead of re-posting the MOTD.
+            if str_tmp.startswith("MOTD:"):
+                self.logger.info("MOTD suppressed from Discord: " + str_tmp)
+                return
+
+            # Server/MOTD lines may be sent as source -1 on automatic reconnect.
+            # getUsername(-1) normalizes this to "server" for Discord output.
             self.discord.sayChat(str_tmp, packet.source)
 
             # ignore chat from ourself

--- a/RoRnet.py
+++ b/RoRnet.py
@@ -1,6 +1,6 @@
 import struct, logging, time
 
-RORNET_VERSION = "RoRnet_2.45"
+RORNET_VERSION = "RoRnet_2.44"
 
 MSG2_HELLO                      = 1025                #!< client sends its version as first message
 # hello responses

--- a/services_start.py
+++ b/services_start.py
@@ -62,6 +62,7 @@ class Config:
                 'host': None,
                 'port': 0,
                 'password': '',
+                'protocolversion': 'RoRnet_2.44',
 
                 'username': 'services',
                 'usertoken': '',
@@ -77,8 +78,8 @@ class Config:
                         # },
                 },
 
-                'reconnection_interval': 5,
-                'reconnection_tries': 3,
+                'reconnection_interval': 10,
+                'reconnection_tries': 30,
         }
 
         # Fill the whole settings dictionary with default values
@@ -174,6 +175,7 @@ class Config:
             s['host']     = RoRclient.find("./server").get("host", default=s['host'])
             s['port'] = int(RoRclient.find("./server").get("port", default=s['port']))
             s['password'] = RoRclient.find("./server").get("password", default=s['password'])
+            s['protocolversion'] = RoRclient.find("./server").get("protocolversion", default=RoRclient.find("./server").get("protocol", default=s['protocolversion']))
         if ( s['host'] is None or s['port']==0 ) and ID != "default/template":
             self.logger.error("configuration/RoRclients/RoRclient(%s)/server[@host, @port] needs to be set!", ID)
             self.logger.error("Ignoring RoRclient(%s)", ID)
@@ -193,6 +195,12 @@ class Config:
             s['username']     = RoRclient.find("./user").get("name", default=s['username'])
             s['usertoken']    = RoRclient.find("./user").get("token", default=s['usertoken'])
             s['userlanguage'] = RoRclient.find("./user").get("language", default=s['userlanguage'])
+
+        # if an element <reconnect> exists
+        if not RoRclient.find("./reconnect") is None:
+            reconnect = RoRclient.find("./reconnect")
+            s['reconnection_interval'] = int(reconnect.get("interval", default=s['reconnection_interval']))
+            s['reconnection_tries'] = int(reconnect.get("tries", default=s['reconnection_tries']))
 
         # if an element <announcements> exists
         if not RoRclient.find("./announcements") is None:
@@ -317,7 +325,7 @@ class Main(discord.Client):
                 self.RoRclients[ID].setName('RoR_thread_'+ID)
                 self.RoRclients[ID].start()
 
-    def isVehicleBanned(self, truck):
+    def validate(self, truck):
         if os.path.isfile('truck.blacklist') == False:
             return False
 


### PR DESCRIPTION
This PR improves RoRBot behavior when a connected RoR server restarts, briefly goes offline, or otherwise drops the bot connection.

Previously, the bot could exhaust reconnect attempts too quickly during a normal server restart. This could cause temporary connection failures to be posted into Discord even though the server was still in the process of coming back online.

Changes included:

* Extends the default reconnect window so the bot waits longer before giving up.
* Resets reconnect attempts after a successful connection.
* Keeps temporary reconnect failures out of Discord while the bot is still retrying.
* Still reports an error if reconnect attempts are fully exhausted.
* Normalizes RoR server/system chat source ID `-1` to `server` instead of showing `unknown(-1)`.
* Suppresses MOTD chat lines from Discord output so reconnects do not repost the full server MOTD every time.
* Keeps normal player chat, join messages, leave messages, and connected-status messages posting as before.
* Preserves the existing truck/bundle stream-name parsing logic, including handling stream names in the `bundle:filename` format.

Testing performed:

* Restarted a RoR server while the bot was connected.
* Confirmed the bot reconnected after the server came back online.
* Confirmed temporary reconnect failures were not posted to Discord.
* Confirmed MOTD lines were not reposted to Discord after reconnect.
* Confirmed normal join/leave and connected messages still appeared.
